### PR TITLE
ci: configurar workflow para ramas main y develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         version: "latest"
     
     - name: Install dependencies
-      run: uv sync --dev
+      run: uv sync --all-extras
     
     - name: Lint with ruff
       run: uv run ruff check .
@@ -72,7 +72,7 @@ jobs:
         version: "latest"
     
     - name: Install dependencies
-      run: uv sync --dev
+      run: uv sync --all-extras
     
     - name: Test with pytest
       run: uv run pytest
@@ -102,7 +102,7 @@ jobs:
         version: "latest"
     
     - name: Install build dependencies
-      run: uv sync --dev
+      run: uv sync --all-extras
     
     - name: Build package
       run: uv build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         version: "latest"
     
     - name: Install dependencies
-      run: uv sync --dev
+      run: uv sync --all-extras
     
     - name: Build package
       run: uv build


### PR DESCRIPTION
- AÃ±adir rama develop a los triggers de CI
- Configurar build para ejecutarse en push a main y develop
- Seguir protocolo de Git: develop para desarrollo, main para producciÃ³n
